### PR TITLE
Added API to use JH database

### DIFF
--- a/src/moh_data/core/query.py
+++ b/src/moh_data/core/query.py
@@ -1,4 +1,3 @@
-from urllib.request import urlopen
 import requests
 from bs4 import BeautifulSoup, SoupStrainer
 
@@ -10,12 +9,6 @@ class FindExcelFile(object):
     def __init__(self):
         self._parent_url = "https://www.health.govt.nz/"
         self._cases_url = self._parent_url + CASES_URL
-
-        url_reader = urlopen(self._cases_url)
-        try:
-            html = url_reader.read().decode('utf-8')
-        finally:
-            url_reader.close()
 
         self._response = requests.get(self._cases_url)
         self._soup = BeautifulSoup(self._response.content, 'html.parser', parse_only=SoupStrainer('a'))

--- a/src/moh_data/main.py
+++ b/src/moh_data/main.py
@@ -76,7 +76,7 @@ class Basic:
                              .format(day, len(sheet) - 1))
         return int(sheet.iloc[day])
 
-    def get_cumulative_recovered(self, day):
+    def get_cumulative_recovered_cases_on(self, day):
         """
         Get the cumulative number of total recovered cases on a particular date
 
@@ -86,7 +86,7 @@ class Basic:
         df = self._database.get_cumulative_recovered()
         return df[df.columns[day]].values[-1]
 
-    def get_cumulative_dead(self, day):
+    def get_cumulative_dead_cases_on(self, day):
         """
         Get the cumulative number of total dead cases on a particular date
 
@@ -250,8 +250,8 @@ if __name__ == '__main__':
         print('Cumulative confirmed cases on day 41 = ', run_data.get_cumulative_confirmed_cases_on_day(40))
         print('Cumulative probable cases on day 41 = ', run_data.get_cumulative_probable_cases_on_day(40))
         print('Cumulative total cases on day 41 = ', run_data.get_cumulative_total_cases_on_day(40))
-        print('Cumulative recovered cases on day 80 = ', run_data.get_cumulative_recovered(80))
-        print('Cumulative dead cases on day 80 = ', run_data.get_cumulative_dead(80))
+        print('Cumulative recovered cases on day 80 = ', run_data.get_cumulative_recovered_cases_on(80))
+        print('Cumulative dead cases on day 80 = ', run_data.get_cumulative_dead_cases_on(80))
 
         print('Confirmed cases on 2020-04-14 = ', run_data.get_confirmed_cases_on_date((4, 14)))
         print('Confirmed cases between 2020-04-08 and 2020-04-14 =',

--- a/src/moh_data/main.py
+++ b/src/moh_data/main.py
@@ -247,9 +247,9 @@ if __name__ == '__main__':
         run_data.plot_daily_arrival_sum()
         run_data.plot_overseas_date_reported()
 
-        print('Cumulative confirmed cases on day 41 = ', run_data.get_cumulative_confirmed_cases_on_day(40))
-        print('Cumulative probable cases on day 41 = ', run_data.get_cumulative_probable_cases_on_day(40))
-        print('Cumulative total cases on day 41 = ', run_data.get_cumulative_total_cases_on_day(40))
+        print('Cumulative confirmed cases on day 40 = ', run_data.get_cumulative_confirmed_cases_on_day(40))
+        print('Cumulative probable cases on day 40 = ', run_data.get_cumulative_probable_cases_on_day(40))
+        print('Cumulative total cases on day 40 = ', run_data.get_cumulative_total_cases_on_day(40))
         print('Cumulative recovered cases on day 80 = ', run_data.get_cumulative_recovered_cases_on(80))
         print('Cumulative dead cases on day 80 = ', run_data.get_cumulative_dead_cases_on(80))
 

--- a/src/moh_data/main.py
+++ b/src/moh_data/main.py
@@ -84,7 +84,7 @@ class Basic:
         :return:
         """
         df = self._database.get_cumulative_recovered()
-        return df[df.columns[day]].values[-1]
+        return df[df.columns[37+day]].values[-1]
 
     def get_cumulative_dead_cases_on(self, day):
         """
@@ -94,7 +94,7 @@ class Basic:
         :return:
         """
         df = self._database.get_cumulative_dead()
-        return df[df.columns[day]].values[-1]
+        return df[df.columns[37+day]].values[-1]
 
     def get_confirmed_cases_on_date(self, date):
         """

--- a/src/moh_data/main.py
+++ b/src/moh_data/main.py
@@ -247,11 +247,11 @@ if __name__ == '__main__':
         run_data.plot_daily_arrival_sum()
         run_data.plot_overseas_date_reported()
 
-        print('Cumulative confirmed cases on day 40 = ', run_data.get_cumulative_confirmed_cases_on_day(40))
-        print('Cumulative probable cases on day 40 = ', run_data.get_cumulative_probable_cases_on_day(40))
-        print('Cumulative total cases on day 40 = ', run_data.get_cumulative_total_cases_on_day(40))
-        print('Cumulative recovered cases on day 80 = ', run_data.get_cumulative_recovered_cases_on(80))
-        print('Cumulative dead cases on day 80 = ', run_data.get_cumulative_dead_cases_on(80))
+        print('Cumulative confirmed cases on day 45 = ', run_data.get_cumulative_confirmed_cases_on_day(45))
+        print('Cumulative probable cases on day 45 = ', run_data.get_cumulative_probable_cases_on_day(45))
+        print('Cumulative total cases on day 45 = ', run_data.get_cumulative_total_cases_on_day(45))
+        print('Cumulative recovered cases on day 45 = ', run_data.get_cumulative_recovered_cases_on(45))
+        print('Cumulative dead cases on day 45 = ', run_data.get_cumulative_dead_cases_on(45))
 
         print('Confirmed cases on 2020-04-14 = ', run_data.get_confirmed_cases_on_date((4, 14)))
         print('Confirmed cases between 2020-04-08 and 2020-04-14 =',

--- a/src/moh_data/main.py
+++ b/src/moh_data/main.py
@@ -14,7 +14,7 @@ except ImportError:
 class Basic:
 
     def __init__(self):
-        self._excel_file = DataCollector()
+        self._database = DataCollector()
         self._confirmed = None
         self._probable = None
         self._total_daily_confirmed = None
@@ -29,14 +29,14 @@ class Basic:
         self._run()
 
     def _run(self):
-        self._confirmed = self._excel_file.parse_confirmed()
-        self._probable = self._excel_file.parse_probable()
-        self._total_daily_confirmed = self._excel_file.get_daily_sum_confirmed()
-        self._total_daily_probable = self._excel_file.get_daily_sum_probable()
-        self._total_combined = self._excel_file.get_cumulative_sum()
-        self._grand_sum = self._excel_file.get_grand_sum()
-        self._total_arrival = self._excel_file.get_daily_arrival_sum()
-        self._total_overseas_reported_date = self._excel_file.get_overseas_reported_sum()
+        self._confirmed = self._database.parse_confirmed()
+        self._probable = self._database.parse_probable()
+        self._total_daily_confirmed = self._database.get_daily_sum_confirmed()
+        self._total_daily_probable = self._database.get_daily_sum_probable()
+        self._total_combined = self._database.get_cumulative_sum()
+        self._grand_sum = self._database.get_grand_sum()
+        self._total_arrival = self._database.get_daily_arrival_sum()
+        self._total_overseas_reported_date = self._database.get_overseas_reported_sum()
 
     def get_cumulative_confirmed_cases_on_day(self, day):
         """
@@ -83,7 +83,7 @@ class Basic:
         :param day: int corresponding to the day of which data is available for.
         :return:
         """
-        df = self._excel_file.get_cumulative_recovered()
+        df = self._database.get_cumulative_recovered()
         return df[df.columns[day]].values[-1]
 
     def get_cumulative_dead(self, day):
@@ -93,7 +93,7 @@ class Basic:
         :param day: int corresponding to the day of which data is available for.
         :return:
         """
-        df = self._excel_file.get_cumulative_dead()
+        df = self._database.get_cumulative_dead()
         return df[df.columns[day]].values[-1]
 
     def get_confirmed_cases_on_date(self, date):

--- a/src/moh_data/main.py
+++ b/src/moh_data/main.py
@@ -76,6 +76,26 @@ class Basic:
                              .format(day, len(sheet) - 1))
         return int(sheet.iloc[day])
 
+    def get_cumulative_recovered(self, day):
+        """
+        Get the cumulative number of total recovered cases on a particular date
+
+        :param day: int corresponding to the day of which data is available for.
+        :return:
+        """
+        df = self._excel_file.get_cumulative_recovered()
+        return df[df.columns[day]].values[-1]
+
+    def get_cumulative_dead(self, day):
+        """
+        Get the cumulative number of total dead cases on a particular date
+
+        :param day: int corresponding to the day of which data is available for.
+        :return:
+        """
+        df = self._excel_file.get_cumulative_dead()
+        return df[df.columns[day]].values[-1]
+
     def get_confirmed_cases_on_date(self, date):
         """
         Get the number of confirmed cases on a particular date
@@ -230,6 +250,8 @@ if __name__ == '__main__':
         print('Cumulative confirmed cases on day 41 = ', run_data.get_cumulative_confirmed_cases_on_day(40))
         print('Cumulative probable cases on day 41 = ', run_data.get_cumulative_probable_cases_on_day(40))
         print('Cumulative total cases on day 41 = ', run_data.get_cumulative_total_cases_on_day(40))
+        print('Cumulative recovered cases on day 80 = ', run_data.get_cumulative_recovered(80))
+        print('Cumulative dead cases on day 80 = ', run_data.get_cumulative_dead(80))
 
         print('Confirmed cases on 2020-04-14 = ', run_data.get_confirmed_cases_on_date((4, 14)))
         print('Confirmed cases between 2020-04-08 and 2020-04-14 =',


### PR DESCRIPTION
This PR is partly related to issue (https://github.com/ABI-Covid-19/moh-data/issues/9). 

- We can now fetch the recovered and dead cases (cumulative) from JH database and combine it with the MoH data that we were already getting.
- Also, the code now automatically fills in the missing dates in the MoH data. Thanks to @agarny for detecting this issue.